### PR TITLE
Fix installation error by making mlx optional

### DIFF
--- a/median/download.py
+++ b/median/download.py
@@ -1,7 +1,15 @@
 import spacy.cli
-from mlx_lm import load
 
-model_name = "mlx-community/Mistral-7B-Instruct-v0.2-4bit"
-load(model_name, lazy=False)
+try:
+    from mlx_lm import load
+
+    model_name = "mlx-community/Mistral-7B-Instruct-v0.2-4bit"
+    load(model_name, lazy=False)
+except ImportError:  # pragma: no cover - fallback for non-macOS platforms
+    from transformers import AutoModelForCausalLM, AutoTokenizer
+
+    model_name = "distilgpt2"
+    AutoTokenizer.from_pretrained(model_name)
+    AutoModelForCausalLM.from_pretrained(model_name)
 
 spacy.cli.download("en_core_web_sm")

--- a/median/llm_provider.py
+++ b/median/llm_provider.py
@@ -1,6 +1,13 @@
 import os
 
-from mlx_lm import generate, load
+try:
+    from mlx_lm import generate, load
+    _USE_MLX = True
+except ImportError:  # pragma: no cover - fallback for non-macOS platforms
+    from transformers import AutoModelForCausalLM, AutoTokenizer
+    import torch
+
+    _USE_MLX = False
 
 from median.utils import median_logger
 
@@ -16,7 +23,12 @@ def load_model():
     os.environ["TOKENIZERS_PARALLELISM"] = "false"
 
     model_name = "mlx-community/Mistral-7B-Instruct-v0.2-4bit"
-    model, tokenizer = load(model_name, lazy=False)
+    if _USE_MLX:
+        model, tokenizer = load(model_name, lazy=False)
+    else:  # fallback to a lightweight Transformers model
+        model_name = "distilgpt2"
+        tokenizer = AutoTokenizer.from_pretrained(model_name)
+        model = AutoModelForCausalLM.from_pretrained(model_name)
     median_logger.info("Loaded model and tokenizer")
     return model, tokenizer
 
@@ -35,7 +47,17 @@ def run_inference(model, tokenizer, prompt, model_config):
         str: The generated output based on the model and prompt.
     """
 
-    return generate(model, tokenizer, prompt=prompt, **model_config)
+    if _USE_MLX:
+        return generate(model, tokenizer, prompt=prompt, **model_config)
+    input_ids = tokenizer(prompt, return_tensors="pt").input_ids
+    with torch.no_grad():
+        output_ids = model.generate(
+            input_ids,
+            max_new_tokens=model_config.get("max_tokens", 256),
+            temperature=model_config.get("temp", 0.7),
+            repetition_penalty=model_config.get("repetition_penalty", 1.1),
+        )
+    return tokenizer.decode(output_ids[0], skip_special_tokens=True)
 
 
 def generation(content: str, language: str, followings: str):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
-jsonschema == 4.21.1
+jsonschema==4.21.1
 langchain==0.1.13
 langdetect==1.0.9
-mlx-lm==0.4.0
 pydantic==2.6.4
 spacy==3.7.4
 transformers==4.39.0
@@ -11,8 +10,7 @@ torchvision==0.17.1
 torchaudio==2.2.1
 sentencepiece==0.2.0
 
-
 streamlit==1.32.2
 pypdf==4.1.0
-python-docx ==1.1.0
+python-docx==1.1.0
 ebisu==2.1.0


### PR DESCRIPTION
## Summary
- remove `mlx-lm` from requirements
- allow fallback to `transformers` when `mlx` isn't available
- update download script to load a small fallback model

## Testing
- `python -m py_compile median/llm_provider.py median/download.py`
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`
- `pip install -r requirements.txt` *(fails: cannot access GitHub due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68630f1abac4832989824ef48135be54